### PR TITLE
Port <Variables>/"="-expression support to the stackup reader; fix description format

### DIFF
--- a/workflow/modules/util_stackup_reader.py
+++ b/workflow/modules/util_stackup_reader.py
@@ -36,11 +36,25 @@
 #              tolerance, so floating-point noise between two independently-accumulated
 #              z values that represent the same physical boundary can no longer misassign
 #              a boundary-sitting metal (zero real overlap) to the dielectric below it
+# 18 Aug 2026: added <Variables>/<Variable> and "="-prefixed expression support, usable in
+#              any attribute value anywhere in the file (Materials, Dielectrics, Layers,
+#              Substrate, DerivedLayers, Tables) - see doc/XML_stackup_format section
+#              "<Variables>"; bumped schema to "3.1"
+# 18 Aug 2026: added variable_overrides parameter to read_substrate()/parse_substrate(), so
+#              an external caller (e.g. a parametric sweep script) can override a <Variable>'s
+#              value without editing the XML file - see variables_list.apply_overrides()
+# 18 Aug 2026: made the "variables" argument optional (default None -> empty variables_list)
+#              on stackup_material/dielectric_layer/metal_layer/derived_layer/thermal_table,
+#              so a caller built before <Variables> existed (e.g. setupEM's stackup_editor.py,
+#              which constructs these directly rather than via parse_substrate()) keeps working
+#              unchanged for ordinary files, instead of every call raising TypeError outright
 
-__version__ = "1.6.1"
+__version__ = "1.7.2"
 
 import os
 import math
+import ast
+import operator
 import xml.etree.ElementTree
 
 # Highest <Stackup schemaVersion="..."> this reader understands. schemaVersion is otherwise
@@ -48,16 +62,8 @@ import xml.etree.ElementTree
 # was written by a newer gds2palace than the one doing the reading, since such a file may use
 # attributes this version of the reader doesn't know about yet. Bump this whenever a schema
 # change actually needs a newer reader to be interpreted correctly (e.g. Reference/
-# ReferenceEdge bumped the format to "3.0").
-SUPPORTED_SCHEMA_VERSION = "3.0"
-
-
-def safe_get (data, key, default):
-  val = data.get(key)
-  if val is not None:
-    return val
-  else:
-    return default
+# ReferenceEdge bumped the format to "3.0"; <Variables>/"=" expressions bumped it to "3.1").
+SUPPORTED_SCHEMA_VERSION = "3.1"
 
 
 def _parse_schema_version (version_string):
@@ -103,6 +109,412 @@ def _make_comment_preserving_parser():
   return xml.etree.ElementTree.XMLParser(target=target)
 
 
+# -------------------- "=" expression evaluation ---------------------------
+#
+# Any attribute value starting with "=" is a restricted-arithmetic expression, evaluated
+# against already-resolved <Variables> (see the "variables"/"variables_list" classes below).
+# A bare variable reference is just the trivial one-token case of an expression (e.g. "=w").
+# This grammar deliberately supports only +,-,*,/,**, unary +/-, parentheses, numeric and
+# string literals, and bare names - no function calls, string concatenation, comparisons,
+# subscripts, or attribute access - so ast.parse()+a restricted node visitor is a safe
+# evaluator, never Python's own eval()/exec().
+
+_ALLOWED_BINOPS = {
+  ast.Add: operator.add,
+  ast.Sub: operator.sub,
+  ast.Mult: operator.mul,
+  ast.Div: operator.truediv,
+  ast.Pow: operator.pow,
+}
+
+_ALLOWED_UNARYOPS = {
+  ast.UAdd: operator.pos,
+  ast.USub: operator.neg,
+}
+
+
+class _ExpressionError (Exception):
+  """A "="-expression is not syntactically valid, or uses syntax outside the restricted
+     grammar (e.g. a function call), or mixes a string-typed variable into arithmetic.
+     Callers catch this to add file/attribute context before print+exit(1).
+  """
+  pass
+
+
+class _UndefinedVariableError (Exception):
+  """A "="-expression's ast.Name node isn't in the values dict passed to evaluation. Raised
+     both for a genuinely undefined variable name and (during variables_list.resolve_all()'s
+     dependency worklist) for a variable that exists but isn't resolved yet - the two cases
+     are told apart by the caller, which knows which names actually exist.
+  """
+  def __init__ (self, name):
+    super().__init__(name)
+    self.name = name
+
+
+def _expression_names (expr_str):
+  """Parse a "="-expression's body (leading "=" already stripped) and return the set of bare
+     identifier names it references, without evaluating it. Used by variable dependency
+     resolution to check readiness before actually evaluating.
+  Args:
+      expr_str (string): expression text, leading "=" already stripped
+  Returns:
+      set of string: variable names referenced in the expression
+  Raises:
+      _ExpressionError: if expr_str is not syntactically a valid expression
+  """
+  try:
+    tree = ast.parse(expr_str, mode="eval")
+  except SyntaxError as e:
+    raise _ExpressionError(str(e))
+  return {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+
+
+def _eval_expression_ast (node, values):
+  """Recursively evaluate one ast node under the restricted expression grammar.
+  Args:
+      node (ast.AST): node to evaluate
+      values (dict): variable name -> already-resolved value (float or str)
+  Returns:
+      float or str
+  Raises:
+      _ExpressionError: disallowed syntax, or a string value used in arithmetic
+      _UndefinedVariableError: a Name node not present in `values`
+  """
+  if isinstance(node, ast.Expression):
+    return _eval_expression_ast(node.body, values)
+  if isinstance(node, ast.Constant) and isinstance(node.value, (int, float, str)):
+    return node.value
+  if isinstance(node, ast.Name):
+    if node.id not in values:
+      raise _UndefinedVariableError(node.id)
+    return values[node.id]
+  if isinstance(node, ast.BinOp) and type(node.op) in _ALLOWED_BINOPS:
+    left = _eval_expression_ast(node.left, values)
+    right = _eval_expression_ast(node.right, values)
+    if isinstance(left, str) or isinstance(right, str):
+      raise _ExpressionError('a string-typed variable cannot be used in arithmetic')
+    return _ALLOWED_BINOPS[type(node.op)](left, right)
+  if isinstance(node, ast.UnaryOp) and type(node.op) in _ALLOWED_UNARYOPS:
+    operand = _eval_expression_ast(node.operand, values)
+    if isinstance(operand, str):
+      raise _ExpressionError('a string-typed variable cannot be used in arithmetic')
+    return _ALLOWED_UNARYOPS[type(node.op)](operand)
+  raise _ExpressionError('unsupported syntax (only +,-,*,/,**, unary +/-, parentheses, '
+                          'numbers, strings, and variable names are allowed)')
+
+
+def _eval_expression (expr_str, values):
+  """Evaluate a "="-expression's body (leading "=" already stripped) against a dict of
+     already-resolved variable values.
+  Args:
+      expr_str (string): expression text
+      values (dict): variable name -> value (float or str)
+  Returns:
+      float or str: the expression result
+  Raises:
+      _ExpressionError, _UndefinedVariableError
+  """
+  try:
+    tree = ast.parse(expr_str, mode="eval")
+  except SyntaxError as e:
+    raise _ExpressionError(str(e))
+  return _eval_expression_ast(tree, values)
+
+
+def _infer_literal_value (raw_value):
+  """Infer number vs. string for a plain (non-"=") Variable Value: parses as float -> number,
+     otherwise string. Mirrors how every other numeric attribute in this file is parsed
+     (bare float()), just without assuming success.
+  Args:
+      raw_value (string): raw Value attribute text
+  Returns:
+      float or str
+  """
+  try:
+    return float(raw_value)
+  except (TypeError, ValueError):
+    return raw_value
+
+
+def resolve_attr (data, key, default, variables):
+  """Return an attribute's value: `default` if the attribute is absent, the raw string
+     unchanged if it's a plain literal, or the result of evaluating a "="-prefixed expression
+     against `variables` if present. This is the single choke point every attribute value in
+     the stackup file passes through, so "=" expressions work uniformly everywhere (Materials,
+     Dielectrics, Layers, Substrate, DerivedLayers, Tables) without each call site needing its
+     own logic. A numeric expression result is returned as its str() so every existing
+     float(...) call site keeps working unchanged; a string result (a plain literal without
+     "=", or a string-typed variable) is returned as-is.
+  Args:
+      data (xml.etree.ElementTree.Element): source of the raw attribute
+      key (string): attribute name
+      default: value to return if the attribute is absent
+      variables (variables_list): fully-resolved variables to evaluate expressions against
+  Returns:
+      string, or `default` unchanged if the attribute is absent
+  """
+  raw = data.get(key)
+  if raw is None:
+    return default
+  if not (isinstance(raw, str) and raw.startswith("=")):
+    return raw
+  try:
+    result = _eval_expression(raw[1:], variables.as_dict())
+  except _UndefinedVariableError as e:
+    print('ERROR: attribute ', key, '="', raw, '" references undefined variable "', e.name, '"')
+    exit(1)
+  except _ExpressionError as e:
+    print('ERROR: attribute ', key, '="', raw, '" is an invalid expression: ', str(e))
+    exit(1)
+  return str(result) if isinstance(result, (int, float)) else result
+
+
+def resolve_int_attr (data, key, variables):
+  """Like resolve_attr(), but for GDSII layer-number attributes (<Layer Layer="...">,
+     <DerivedLayer Layer="...">, <Operand Layer="...">, <Dielectric Boundary="...">): the
+     resolved value must be an integer-valued number - an expression may legitimately produce
+     e.g. 126.0 from variable arithmetic (fine), but a genuinely fractional result is an error,
+     not a silent truncation. Returns the value as a plain integer string, so existing
+     int(...)/string-equality call sites are unaffected whether the attribute was a literal or
+     an expression.
+  Args:
+      data (xml.etree.ElementTree.Element): source of the raw attribute
+      key (string): attribute name
+      variables (variables_list): fully-resolved variables to evaluate expressions against
+  Returns:
+      string: the layer number as a plain integer string, or None if the attribute is absent
+  """
+  resolved = resolve_attr(data, key, None, variables)
+  if resolved is None:
+    return None
+  try:
+    numeric_value = float(resolved)
+  except (TypeError, ValueError):
+    print('ERROR: attribute ', key, '="', resolved, '" must be a GDSII layer number (integer)')
+    exit(1)
+  if numeric_value != int(numeric_value):
+    print('ERROR: attribute ', key, '="', resolved, '" evaluates to ', numeric_value,
+          ', which is not a whole number - GDSII layer numbers must be integers')
+    exit(1)
+  return str(int(numeric_value))
+
+
+# -------------------- variables ---------------------------
+
+class variable:
+  """
+    named value (number or string; a plain literal, or a "="-prefixed expression that may
+    reference other variables) that any other attribute in the stackup file can refer to.
+  """
+
+  def __init__ (self, data):
+    """create variable object from XML data line
+
+    Args:
+        data (xml.etree.ElementTree.Element): "Variable" XML element, required attributes
+          "Name" and "Value"; optional "Type" ("number" or "string"). For a plain-literal
+          Value, an explicit Type controls parsing (Type="string" keeps a numeric-looking
+          literal as text instead of inferring it as a number); if omitted, Type is inferred
+          by trying to parse Value as a number. A "Value" starting with "=" is an expression,
+          resolved later by resolve() once every variable it depends on is itself resolved -
+          there Type cannot override the computed result's type, so it is only validated
+          against it (a mismatch is an error). Plain literals have no dependency on other
+          variables, so they're resolvable immediately.
+    """
+    self.name = data.get("Name")
+    self.raw_value = data.get("Value")
+
+    type_attr = data.get("Type")
+    self.declared_type = type_attr.lower() if type_attr is not None else None
+    if self.declared_type not in (None, "number", "string"):
+      print('ERROR: Variable ', self.name, ' has invalid Type="', type_attr, '", must be number or string')
+      exit(1)
+
+    self.value = None      # set once resolved: float or str
+    self.resolved = False
+    self.overridden = False   # set True by apply_override(), for __str__/debugging
+    self.is_expression = isinstance(self.raw_value, str) and self.raw_value.startswith("=")
+
+    if not self.is_expression:
+      # plain literal: resolvable immediately, no dependency on other variables. Explicit
+      # Type controls parsing here (not just validates), since a literal's textual form is
+      # inherently ambiguous - "123" could be meant as either a number or a string, and
+      # Type="string" is precisely how to force the latter.
+      if self.declared_type == "string":
+        self.value = self.raw_value
+      elif self.declared_type == "number":
+        try:
+          self.value = float(self.raw_value)
+        except (TypeError, ValueError):
+          print('ERROR: Variable ', self.name, ' declared Type="number" but Value="', self.raw_value, '" does not parse as a number')
+          exit(1)
+      else:
+        self.value = _infer_literal_value(self.raw_value)
+      self.resolved = True
+
+
+  def _check_declared_type (self):
+    """If Type was given explicitly, validate it against the actual evaluated type of an
+       expression-valued self.value; ERROR/exit(1) on mismatch. Only meaningful for
+       expressions - a literal's Type already controlled parsing in __init__, so it can never
+       mismatch by the time this would apply to one.
+    """
+    actual_type = "number" if isinstance(self.value, float) else "string"
+    if self.declared_type is not None and self.declared_type != actual_type:
+      print('ERROR: Variable ', self.name, ' declared Type="', self.declared_type,
+            '" but Value evaluates to a ', actual_type)
+      exit(1)
+
+
+  def resolve (self, variables_list_):
+    """Resolve an expression-valued variable using already-resolved variables. No-op if
+       already resolved (plain literals are resolved in __init__).
+    Args:
+        variables_list_ (variables_list): variables to look up by name inside the expression
+    """
+    if self.resolved:
+      return
+    try:
+      self.value = _eval_expression(self.raw_value[1:], variables_list_.as_dict())
+    except _UndefinedVariableError as e:
+      # defensive: variables_list.resolve_all() is expected to only call resolve() once every
+      # variable this one's expression references is itself already resolved
+      print('ERROR: Variable ', self.name, ' references variable "', e.name, '" which is not yet resolved')
+      exit(1)
+    except _ExpressionError as e:
+      print('ERROR: Variable ', self.name, ' has an invalid expression: ', str(e))
+      exit(1)
+    self._check_declared_type()
+    self.resolved = True
+
+
+  def apply_override (self, new_value):
+    """Replace this variable's resolved value with an externally supplied override (e.g. from
+       a parametric sweep script). Takes effect immediately, before resolve_all() runs - no
+       expression parsing or dependency resolution needed, since the override IS the final
+       value. Bypasses whatever the XML itself declared for this variable (a literal or a
+       "="-expression, doesn't matter which). self.declared_type (if the XML gave one) is
+       still validated against it.
+    Args:
+        new_value: override value - a plain float/int for a numeric variable, or a str for a
+          string-typed one
+    """
+    self.value = new_value if isinstance(new_value, str) else float(new_value)
+    self.resolved = True
+    self.overridden = True
+    self._check_declared_type()
+
+
+  def __str__ (self):
+    """String representation of variable, useful for debugging
+    Returns:
+        string: String representation of variable
+    """
+    overridden_suffix = ' (overridden)' if self.overridden else ''
+    return '      Variable Name=' + self.name + ' Value=' + str(self.value) + overridden_suffix
+
+
+
+class variables_list:
+  """
+    list of variable objects, with dependency resolution ("=" expressions may reference
+    other variables regardless of declaration order) and lookup by name.
+  """
+
+  def __init__ (self):
+    """Create empty list
+    """
+    self.variables = []
+
+  def append (self, var):
+    """Append one variable
+    Args:
+        var (variable): variable to add
+    """
+    self.variables.append(var)
+
+  def get_by_name (self, name_to_find):
+    """find variable object from name
+    Args:
+        name_to_find (string): Name as specified in XML data line
+    Returns:
+        variable: the variable with that name, or None
+    """
+    for var in self.variables:
+      if var.name == name_to_find:
+        return var
+    return None
+
+  def as_dict (self):
+    """Values of every resolved variable, for evaluating "=" expressions elsewhere in the
+       stackup file. Only meaningful after resolve_all() has run.
+    Returns:
+        dict: variable name -> float or str
+    """
+    return {var.name: var.value for var in self.variables if var.resolved}
+
+  def apply_overrides (self, overrides):
+    """Apply externally supplied variable-value overrides (e.g. from a parametric sweep
+       script), before resolve_all() runs. Every override key must name a <Variable> already
+       defined in the file - ERROR/exit(1) on an unknown name, so a typo in the override dict
+       is caught immediately instead of silently doing nothing or defining an unused variable.
+    Args:
+        overrides (dict): variable name -> plain override value (float/int/str) - see
+          variable.apply_override()
+    """
+    if not overrides:
+      return
+    for name, new_value in overrides.items():
+      var = self.get_by_name(name)
+      if var is None:
+        print('ERROR: variable_overrides references variable "', name, '" which is not defined in this stackup file')
+        exit(1)
+      var.apply_override(new_value)
+
+
+  def resolve_all (self):
+    """Resolve every variable's value, in dependency order (repeat until no progress) - same
+       approach as metal_layers_list.resolve_references()/derived_layers_list.get_ordered().
+       An expression referencing a name that is never defined as a Variable is a hard error
+       reported immediately (not left to fall out as "circular"); a name that exists but isn't
+       resolved yet just defers this variable to a later pass. Any variable already resolved
+       via apply_override() beforehand is skipped here (see the "not var.resolved" filter
+       below), so an override transparently short-circuits whatever the XML itself declared.
+    """
+    remaining = [var for var in self.variables if not var.resolved]
+
+    while remaining:
+      progress = False
+      still_remaining = []
+
+      for var in remaining:
+        try:
+          needed = _expression_names(var.raw_value[1:])
+        except _ExpressionError as e:
+          print('ERROR: Variable ', var.name, ' has an invalid expression: ', str(e))
+          exit(1)
+
+        missing = [name for name in needed if self.get_by_name(name) is None]
+        if missing:
+          print('ERROR: Variable ', var.name, ' references undefined variable(s): ', missing)
+          exit(1)
+
+        pending = [name for name in needed if not self.get_by_name(name).resolved]
+        if not pending:
+          var.resolve(self)
+          progress = True
+        else:
+          still_remaining.append(var)
+
+      if not progress:
+        unresolved_names = [var.name for var in still_remaining]
+        print('ERROR: Circular reference among Variables: ', unresolved_names)
+        exit(1)
+
+      remaining = still_remaining
+
+
 # -------------------- material types ---------------------------
 
 class stackup_material:
@@ -110,26 +522,33 @@ class stackup_material:
     stackup material object, can be dielectric or metal with conductivity or sheet with Ohm/square
   """
     
-  def __init__ (self, data):
+  def __init__ (self, data, variables=None):
     """create stackup material object from XML data line
 
     Args:
         data (string): line from XML data, required parameters are "Name" and "Type" strings. Optional: "Permittivity","DielectricLossTangent","Conductivity","Rs","Color"
+        variables (variables_list, optional): fully-resolved <Variables>, for resolving any
+          "="-prefixed expression among this material's attributes. Defaults to an empty
+          variables_list if omitted - fine for a file with no expressions; a caller that omits
+          this for a file that does use one gets a clear _UndefinedVariableError-driven message
+          instead of this constructor raising TypeError outright.
     """
+    if variables is None:
+      variables = variables_list()
 
 
-    self.name = data.get("Name")
-    self.type = data.get("Type").upper()
-    
-    self.eps   = float(safe_get(data, "Permittivity", 1))
-    self.tand  = float(safe_get(data, "DielectricLossTangent", 0))
-    self.sigma = float(safe_get(data, "Conductivity", 0))
-    self.Rs    = float(safe_get(data, "Rs", 0))
-    self.density = float(safe_get(data, "Density", 1))
-    self.color = data.get("Color")  # no default here, will be handled later 
+    self.name = resolve_attr(data, "Name", None, variables)
+    self.type = resolve_attr(data, "Type", None, variables).upper()
 
-    self.thermalcond = float(safe_get(data, "ThermalConductivity", 0))
-    self.thermaltablename = safe_get(data, "ThermalConductivityTable", "")
+    self.eps   = float(resolve_attr(data, "Permittivity", 1, variables))
+    self.tand  = float(resolve_attr(data, "DielectricLossTangent", 0, variables))
+    self.sigma = float(resolve_attr(data, "Conductivity", 0, variables))
+    self.Rs    = float(resolve_attr(data, "Rs", 0, variables))
+    self.density = float(resolve_attr(data, "Density", 1, variables))
+    self.color = resolve_attr(data, "Color", None, variables)  # no default here, will be handled later
+
+    self.thermalcond = float(resolve_attr(data, "ThermalConductivity", 0, variables))
+    self.thermaltablename = resolve_attr(data, "ThermalConductivityTable", "", variables)
     self.thermaltable = None
 
 
@@ -191,7 +610,7 @@ class dielectric_layer:
     dielectric layer object. Holds information on stackup layers that are always there, without drawing them explicitely in GDSII
   """
     
-  def __init__ (self, data):
+  def __init__ (self, data, variables=None):
     """create stackup layer object (usually dielectric or semiconductor) from XML data line
 
     Args:
@@ -200,19 +619,24 @@ class dielectric_layer:
           Optional "Reference"/"ReferenceEdge": if "Reference" names another Dielectric, "Zmin"
           (default 0) and "Zmax" (default Zmin+Thickness) are offsets from that Dielectric's edge
           instead of absolute z, resolved later by resolve().
+        variables (variables_list, optional): fully-resolved <Variables>, for resolving any
+          "="-prefixed expression among this dielectric's attributes. Defaults to an empty
+          variables_list if omitted - see stackup_material.__init__ for why.
     """
-    self.name = data.get("Name")
-    self.material = data.get("Material")
+    if variables is None:
+      variables = variables_list()
+    self.name = resolve_attr(data, "Name", None, variables)
+    self.material = resolve_attr(data, "Material", None, variables)
 
-    self.reference = data.get("Reference") or None
-    self.reference_edge = data.get("ReferenceEdge", "Top")
+    self.reference = resolve_attr(data, "Reference", None, variables) or None
+    self.reference_edge = resolve_attr(data, "ReferenceEdge", "Top", variables)
     # set True by dielectric_layers_list._assign_implicit_references() for a dielectric that had
     # no explicit Reference in the XML but got one auto-derived from implicit Thickness-stacking
     self.reference_is_auto = False
 
-    zmin_attr = safe_get(data, "Zmin", None)
-    zmax_attr = safe_get(data, "Zmax", None)
-    thickness_attr = data.get("Thickness")
+    zmin_attr = resolve_attr(data, "Zmin", None, variables)
+    zmax_attr = resolve_attr(data, "Zmax", None, variables)
+    thickness_attr = resolve_attr(data, "Thickness", None, variables)
 
     if self.reference:
       # Reference set: Zmin/Zmax (if given) are offsets from the reference edge. Unlike <Layer>,
@@ -245,7 +669,7 @@ class dielectric_layer:
       # (see _assign_implicit_references()), resolved the same way as an explicit Reference.
       self.zmin = None
       self.zmax = None
-      self.thickness  = float(data.get("Thickness"))
+      self.thickness  = float(thickness_attr)
       self.absolute_zpos = False
       self.resolved = False
       # offsets for resolve(): used as-is if _assign_implicit_references() later gives this
@@ -256,7 +680,7 @@ class dielectric_layer:
 
     self.is_top = False
     self.is_bottom = False
-    self.gdsboundary = data.get("Boundary")  # optional entry in stackup file
+    self.gdsboundary = resolve_int_attr(data, "Boundary", variables)  # optional entry in stackup file
 
     self.metals_inside = [] # metals that are located inside this dielectric, set by function
 
@@ -487,24 +911,31 @@ class metal_layer:
     drawing layer object ( name metal_layer is misleading, this drawn layer that uses material from the XML materials section)
   """
     
-  def __init__ (self, data):
+  def __init__ (self, data, variables=None):
     """create metal layer object (planar metal, via, sheet or dielectric) from XML data line
 
     Args:
         data (string): line from XML data, required parameters: "Name","Layer","Type","Material","Zmin","Zmax".
           Optional "Reference"/"ReferenceEdge": if "Reference" names another Dielectric or Layer, "Zmin"/"Zmax"
           are interpreted as offsets from that layer's edge instead of absolute z, resolved later by resolve().
+        variables (variables_list, optional): fully-resolved <Variables>, for resolving any
+          "="-prefixed expression among this layer's attributes. Defaults to an empty
+          variables_list if omitted - see stackup_material.__init__ for why.
        """
-    self.name = data.get("Name")
-    self.layernum = data.get("Layer")
-    self.type = data.get("Type").upper()
-    self.material = data.get("Material")
+    if variables is None:
+      variables = variables_list()
+    self.name = resolve_attr(data, "Name", None, variables)
+    self.layernum = resolve_int_attr(data, "Layer", variables)
+    self.type = resolve_attr(data, "Type", None, variables).upper()
+    self.material = resolve_attr(data, "Material", None, variables)
 
-    self.reference = data.get("Reference") or None
-    self.reference_edge = data.get("ReferenceEdge", "Top")
+    self.reference = resolve_attr(data, "Reference", None, variables) or None
+    self.reference_edge = resolve_attr(data, "ReferenceEdge", "Top", variables)
 
-    # force to sheet if zero thickness (raw string compare, same convention whether Zmin/Zmax are absolute or offsets)
-    if data.get("Zmin") == data.get("Zmax"):
+    zmin_attr = resolve_attr(data, "Zmin", None, variables)
+    zmax_attr = resolve_attr(data, "Zmax", None, variables)
+    # force to sheet if zero thickness (resolved-value compare, same convention whether Zmin/Zmax are absolute or offsets)
+    if zmin_attr == zmax_attr:
       self.type = "SHEET"
 
     self.is_used = False
@@ -515,14 +946,14 @@ class metal_layer:
 
     if self.reference:
       # Zmin/Zmax are offsets from the resolved Reference edge; actual zmin/zmax are set by resolve()
-      self.offset_zmin = float(data.get("Zmin"))
-      self.offset_zmax = float(data.get("Zmax"))
+      self.offset_zmin = float(zmin_attr)
+      self.offset_zmax = float(zmax_attr)
       self.zmin = None
       self.zmax = None
       self.resolved = False
     else:
-      self.zmin = float(data.get("Zmin"))
-      self.zmax = float(data.get("Zmax"))
+      self.zmin = float(zmin_attr)
+      self.zmax = float(zmax_attr)
       self.resolved = True
       self._finalize_type_flags()
 
@@ -799,7 +1230,7 @@ class derived_layer:
 
   VALID_OPERATIONS = ("AND", "OR", "XOR", "NOT", "SIZE")
 
-  def __init__ (self, data):
+  def __init__ (self, data, variables=None):
     """create derived layer object from XML data line
 
     Args:
@@ -809,22 +1240,27 @@ class derived_layer:
           "Layer" attribute, in order. For "NOT", first operand minus all following operands.
           Order does not matter for "AND", "OR", "XOR". "SIZE" takes exactly one operand and
           requires a non-zero Oversize; it just resizes that operand onto the new layer number.
+        variables (variables_list, optional): fully-resolved <Variables>, for resolving any
+          "="-prefixed expression among this derived layer's (and its Operands') attributes.
+          Defaults to an empty variables_list if omitted - see stackup_material.__init__ for why.
     """
-    self.name = data.get("Name")
-    self.layernum = data.get("Layer")
+    if variables is None:
+      variables = variables_list()
+    self.name = resolve_attr(data, "Name", None, variables)
+    self.layernum = resolve_int_attr(data, "Layer", variables)
 
-    operation = data.get("Operation")
+    operation = resolve_attr(data, "Operation", None, variables)
     self.operation = operation.upper() if operation is not None else None
     if self.operation not in self.VALID_OPERATIONS:
       print('ERROR: Derived layer ', self.name, ' has invalid Operation "', operation, '". Must be one of ', self.VALID_OPERATIONS)
       exit(1)
 
-    oversize = data.get("Oversize")
+    oversize = resolve_attr(data, "Oversize", None, variables)
     self.oversize = float(oversize) if oversize is not None else 0.0
 
     self.operands = []
     for operand in data.findall("Operand"):
-      self.operands.append(operand.get("Layer"))
+      self.operands.append(resolve_int_attr(operand, "Layer", variables))
 
     if self.operation == "SIZE":
       if len(self.operands) != 1:
@@ -938,13 +1374,15 @@ class derived_layers_list:
 # ----------- thermal tables -----------------
 
 class thermal_table:
-    def __init__(self, xml_data):
-        self.name = xml_data.attrib["Name"]
+    def __init__(self, xml_data, variables=None):
+        if variables is None:
+            variables = variables_list()
+        self.name = resolve_attr(xml_data, "Name", None, variables)
         self.points = []
 
         for point in xml_data.iter("Point"):
-            T = float(point.attrib["Temperature"])
-            k = float(point.attrib["Value"])
+            T = float(resolve_attr(point, "Temperature", None, variables))
+            k = float(resolve_attr(point, "Value", None, variables))
             self.points.append((T, k))
 
 
@@ -1015,13 +1453,17 @@ def read_file_description (XML_filename):
   return ""
 
 
-def read_substrate (XML_filename):
+def read_substrate (XML_filename, variable_overrides=None):
   """
   Read XML substrate and return materials_list, dielectrics_list, metals_list.
   Derived layer definitions (if any) are attached as metals_list.derived_layers,
   so this return signature stays backward compatible with existing 3-value unpacking.
   Args:
       XML_filename (string): filename of XML technology file
+      variable_overrides (dict, optional): variable name -> plain override value
+        (float/int/str), applied to this file's <Variables> before anything else is resolved -
+        e.g. from a parametric sweep script. See variables_list.apply_overrides(). None (the
+        default) applies no overrides, leaving every variable exactly as the XML declares it.
   """
 
   if os.path.isfile(XML_filename):
@@ -1037,14 +1479,14 @@ def read_substrate (XML_filename):
     # editor on every edit) - that would otherwise reprint the same warning constantly
     check_schema_version(substrate_root)
 
-    return parse_substrate(substrate_root)
+    return parse_substrate(substrate_root, variable_overrides)
 
   else:
     print('XML stackup file not found: ', XML_filename)
     exit(1)
 
 
-def parse_substrate (substrate_root):
+def parse_substrate (substrate_root, variable_overrides=None):
   """
   Build materials_list, dielectrics_list, metals_list from an already-parsed XML
   <Stackup> root element. This is the part of read_substrate() that doesn't touch
@@ -1053,24 +1495,37 @@ def parse_substrate (substrate_root):
   round trip through the filesystem.
   Args:
       substrate_root (xml.etree.ElementTree.Element): root element of a stackup XML tree
+      variable_overrides (dict, optional): see read_substrate()
   """
+
+  # get variables from XML first (if present) - every other attribute in the file may
+  # reference one via a "="-prefixed expression, so these must be fully resolved before
+  # anything else below is parsed. Overrides are applied before resolve_all() so dependency
+  # resolution sees them from the start - an overridden variable is marked resolved
+  # immediately, so any formula variable built on top of it (overridden or not) picks up the
+  # override value in the same single resolution pass.
+  variables = variables_list()
+  for data in substrate_root.iter("Variable"):
+      variables.append (variable(data))
+  variables.apply_overrides(variable_overrides)
+  variables.resolve_all()
 
   # get materials  from  XML
   materials_list = stackup_materials_list() # initialize empty list
   for data in  substrate_root.iter("Material"):
-      materials_list.append (stackup_material(data))
+      materials_list.append (stackup_material(data, variables))
 
   # get dielectric layers from  XML
   dielectrics_list = dielectric_layers_list() # initialize empty list
   for data in  substrate_root.iter("Dielectric"):
-      dielectrics_list.append (dielectric_layer(data), materials_list)
+      dielectrics_list.append (dielectric_layer(data, variables), materials_list)
 
   # get optional thermal tables from XML
   thermal_tables = thermal_tables_list()
   tables = substrate_root.find("Tables")
   if tables is not None:
       for data in tables.findall("Table"):
-          thermal_tables.append(thermal_table(data))
+          thermal_tables.append(thermal_table(data, variables))
 
   # iterate over materials to check if they refer to a thermal table
   for material in materials_list.materials:
@@ -1105,7 +1560,7 @@ def parse_substrate (substrate_root):
   # get metal layers (metals + vias) from XML
   metals_list = metal_layers_list() # initialize empty list
   for data in  substrate_root.iter("Layer"):
-      metals_list.append (metal_layer(data))
+      metals_list.append (metal_layer(data, variables))
 
   # resolve Reference-based layers (offsets from a Dielectric or another Layer edge) into absolute zmin/zmax
   metals_list.resolve_references(dielectrics_list)
@@ -1119,13 +1574,13 @@ def parse_substrate (substrate_root):
   derived_layers_section = substrate_root.find(".//DerivedLayers")
   if derived_layers_section is not None:
     for data in derived_layers_section.findall("DerivedLayer"):
-      metals_list.derived_layers.append (derived_layer(data))
+      metals_list.derived_layers.append (derived_layer(data, variables))
 
   # get substrate offset, required for v2 stackup file version
   offset = 0
   for data in substrate_root.iter("Substrate"):
       assert data!=None
-      offset = float(data.get("Offset"))
+      offset = float(resolve_attr(data, "Offset", 0, variables))
   if offset > 0:
     referenced_layers = metals_list.has_references()
     if referenced_layers:

--- a/workflow/modules/util_stackup_reader.py
+++ b/workflow/modules/util_stackup_reader.py
@@ -958,10 +958,18 @@ class thermal_tables_list(list):
 
 # ----------- parse substrate file, get materials from list created before -----------
 
+GENERATOR_COMMENT_PREFIX = "Created/modified using the XML Stackup Editor in"
 DESCRIPTION_COMMENT_PREFIX = "File description:"
+_HEADER_SEPARATOR_TEXT = "=" * 60
 # duplicated (not imported) from util_stackup_writer.py deliberately: that module
 # is specific to the interactive XML editor, while this reader module is used by
-# the whole gds2palace pipeline and is meant to stay independent of it.
+# the whole gds2palace pipeline and is meant to stay independent of it. Two formats
+# are recognized: the current one (generator stamp, separator, one comment per
+# description line with nothing prepended, closing separator) and the older one
+# (generator stamp, separator, a single comment prefixed with
+# DESCRIPTION_COMMENT_PREFIX holding the whole possibly-multi-line description) that
+# util_stackup_writer.py itself still reads for backward compatibility with files
+# saved before the format changed.
 
 
 def read_file_description (XML_filename):
@@ -981,6 +989,23 @@ def read_file_description (XML_filename):
     root = xml.etree.ElementTree.parse(XML_filename, parser=_make_comment_preserving_parser()).getroot()
   except xml.etree.ElementTree.ParseError:
     return ""
+
+  children = list(root)
+  if (len(children) >= 2
+      and children[0].tag is xml.etree.ElementTree.Comment
+      and (children[0].text or "").strip().startswith(GENERATOR_COMMENT_PREFIX)
+      and children[1].tag is xml.etree.ElementTree.Comment
+      and (children[1].text or "").strip() == _HEADER_SEPARATOR_TEXT):
+    lines = []
+    for child in children[2:]:
+      if child.tag is not xml.etree.ElementTree.Comment:
+        break
+      text = (child.text or "").strip()
+      if text == _HEADER_SEPARATOR_TEXT:
+        return "\n".join(lines)
+      lines.append(text)
+    # no closing separator found - not a well-formed current-format block, fall
+    # through to the legacy single-comment lookup below
 
   for child in root:
     if child.tag is xml.etree.ElementTree.Comment:


### PR DESCRIPTION
## Summary
- Ports the `<Variables>`/`"="`-expression feature from `gds2palace_ihp_sg13g2`'s independently-duplicated copy of `util_stackup_reader.py`, which had fallen out of sync (this copy was still at 1.6.1/`schemaVersion="3.0"`). Now at 1.7.2/`"3.1"`: `variable`/`variables_list` classes, the AST-based expression evaluator, `resolve_attr()`/`resolve_int_attr()` wired into every attribute-parsing call site, and the `variable_overrides` parameter on `read_substrate()`/`parse_substrate()`.
- `read_file_description()` updated to recognize the Stackup Editor's newer one-comment-per-line description format, while staying backward-compatible with the older single-comment format.

## Test plan
- [x] Verified the ported reader is content-identical to `gds2palace_ihp_sg13g2`'s current version (whitespace/line-ending-tolerant diff), reads a real `<Variables>`-using file (`SG13G2_resistors_200um.xml`) with matching resolved z-positions, and `variable_overrides` correctly propagates through dependent expressions.
- [ ] Manual smoke test through a real openEMS model build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)