### PR TITLE
Remove unused SiO2 Material definition from SG13G2_nosub.xml

### DIFF
--- a/workflow/SG13G2_nosub.xml
+++ b/workflow/SG13G2_nosub.xml
@@ -23,7 +23,6 @@
       <Material Name="AIR" Type="Dielectric" Permittivity="1.0" DielectricLossTangent="0.0" Conductivity="0" Color="d0d0d0"/>
       <Material Name="LOWLOSS" Type="Conductor" Permittivity="1" DielectricLossTangent="0" Conductivity="1E10" Color="ff0000"/>
       <Material Name="MIM_equiv" Type="Dielectric" Permittivity="16.87" DielectricLossTangent="0.0" Conductivity="0" Color="ff0000"/>
-      <Material Name="SiO2" Type="Dielectric" Permittivity="4.1" DielectricLossTangent="0.0" Conductivity="0" Color="fffcad"/>
     </Materials>
     <ELayers LengthUnit="um">
       <Dielectrics>


### PR DESCRIPTION
## Summary
- Removes an unused `<Material Name="SiO2" ...>` definition from `workflow/SG13G2_nosub.xml`.

## Test plan
- N/A - unused material definition removed, no functional change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>