### PR TITLE
Fix hardcoded 50 Ohm in Touchstone header, add CHANGES.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 The files provided here enable openEMS EM simulation with layouts
 created for the IHP SG13G2 RFIC technology.
 
+See [CHANGES.md](./doc/CHANGES.md) for recent additions and fixes.
+
 # Documentation
 An extensive User's Guide of this GDSII to openEMS workflow is available in PDF format here:  
 [Using OpenEMS Python with IHP SG13G2 v2](./doc/Using_OpenEMS_Python_with_IHP_SG13G2_v2.pdf) 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,0 +1,19 @@
+# Change list
+
+This is an (incomplete) list of changes and new features.
+
+## 20-Aug-2026
+Fixed `write_snp()` writing a hardcoded 50 Ohm reference impedance into the Touchstone (`*.snp`) file header regardless of the actual port impedance used in the simulation. All model scripts now pass the real port reference impedance from `simulation_ports`, so the header correctly reflects non-50 Ohm setups (e.g. differential/GSG ports).
+
+## 13-18-Aug-2026
+Added support for derived layers in the stackup XML format, with a new IHP resistor example under `more_examples`.
+
+The stackup reader (`util_stackup_reader.py`) now supports a `<Variables>` block and `=`-prefixed expressions, ported from gds2palace_ihp_sg13g2's reader to keep the two independent copies in sync. This allows a stackup XML file to define named values that other attributes can reference, instead of repeating the same physical value in multiple places.
+
+Keyhole/hole polygons are now split before CSXCAD extrusion, fixing incorrect geometry for layers with holes. This requires the `shapely` package, now a documented dependency.
+
+## 12-Jul-2026
+Added `calculate_Zij()` for multiport Z-parameter extraction (previously only available for 2-port).
+
+## 19-Jun-2026
+New `numThreads` workflow option to force the number of openEMS solver threads, instead of relying on automatic thread count detection. Two examples are provided in the `more_examples` folder.

--- a/more_examples/combine_layout_sources/run_combine_example.py
+++ b/more_examples/combine_layout_sources/run_combine_example.py
@@ -194,7 +194,7 @@ if preview_only==False:
 
     # write Touchstone S2P file
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     fig, axis = plt.subplots(num='Return Loss', tight_layout=True)
     axis.plot(f/1e9, dB(s11), 'k-',  linewidth=2, label='S11 (dB)')

--- a/more_examples/easyMesh/openEMS_generic_nport_MA.py
+++ b/more_examples/easyMesh/openEMS_generic_nport_MA.py
@@ -180,6 +180,6 @@ if not settings['preview_only']:
 
     # Write to Touchstone *.snp file
     snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
-    utilities.write_snp(s_params, f, snp_name)
+    utilities.write_snp(s_params, f, snp_name, z0=simulation_ports.get_reference_impedance())
 
     print('Created S-parameter output file at ', snp_name)

--- a/more_examples/model_syntax_gds2openEMS/gds2openEMS_generic_nport.py
+++ b/more_examples/model_syntax_gds2openEMS/gds2openEMS_generic_nport.py
@@ -177,6 +177,6 @@ for i in range(1, num_ports + 1):
 
 # Write to Touchstone *.snp file
 snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
-utilities.write_snp(s_params, f, snp_name)
+utilities.write_snp(s_params, f, snp_name, z0=simulation_ports.get_reference_impedance())
 
 print('Created S-parameter output file at ', snp_name)

--- a/more_examples/numThreads/openems_core_50ghz_mpa_numThreads.py
+++ b/more_examples/numThreads/openems_core_50ghz_mpa_numThreads.py
@@ -152,7 +152,7 @@ for i in range(1, num_ports + 1):
 
 # Write to Touchstone *.snp file
 snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
-utilities.write_snp(s_params, f, snp_name)
+utilities.write_snp(s_params, f, snp_name, z0=simulation_ports.get_reference_impedance())
 
 print('Created S-parameter output file at ', snp_name)
 

--- a/more_examples/numThreads/run_core_50ghz_mpa_numthreads.py
+++ b/more_examples/numThreads/run_core_50ghz_mpa_numthreads.py
@@ -151,7 +151,7 @@ if preview_only==False:
     s44 = utilities.calculate_Sij (4, 4, f, sim_path, simulation_ports)
 
     s4p_name = os.path.join(sim_path, model_basename + '.s4p')
-    utilities.write_snp (np.array([[s11,s21,s31,s41], [s12,s22,s32,s42], [s13,s23,s33,s43], [s14,s24,s34,s44]]),f, s4p_name)
+    utilities.write_snp (np.array([[s11,s21,s31,s41], [s12,s22,s32,s42], [s13,s23,s33,s43], [s14,s24,s34,s44]]),f, s4p_name, z0=simulation_ports.get_reference_impedance())
 
     print('\nStarting plots')
 

--- a/more_examples/resistors_sg13g2/run_resistors_Rsil.py
+++ b/more_examples/resistors_sg13g2/run_resistors_Rsil.py
@@ -135,6 +135,6 @@ if preview_only==False:
 
     # Write to Touchstone *.snp file
     snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
-    utilities.write_snp(s_params, f, snp_name)
+    utilities.write_snp(s_params, f, snp_name, z0=simulation_ports.get_reference_impedance())
 
     print('Created S-parameter output file at ', snp_name)

--- a/workflow/modules/util_simulation_setup.py
+++ b/workflow/modules/util_simulation_setup.py
@@ -93,8 +93,16 @@ class all_simulation_ports:
       return found       
   
   def get_port_by_number (self, portnum):
-      return self.ports[portnum-1] 
-  
+      return self.ports[portnum-1]
+
+  def get_reference_impedance (self):
+      # common port reference impedance for all ports, raises if ports differ
+      Z0 = self.ports[0].port_Z0
+      for port in self.ports[1:]:
+          if port.port_Z0 != Z0:
+              raise RuntimeError("All ports must use the same reference impedance.")
+      return Z0
+
   def apply_layernumber_offset (self, offset):
       newportlayers = []    
       for port in self.ports:
@@ -1003,7 +1011,7 @@ def runOpenEMS (excite_ports, settings):
 
         # Write to Touchstone *.snp file
         snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
-        utilities.write_snp(s_params, f, snp_name)
+        utilities.write_snp(s_params, f, snp_name, z0=simulation_ports.get_reference_impedance())
 
         print('Created S-parameter output file at ', snp_name)
 

--- a/workflow/modules/util_utilities.py
+++ b/workflow/modules/util_utilities.py
@@ -234,7 +234,7 @@ def calculate_Zij(i, j, f, sim_path, simulation_ports):
 
 # =========================== S-parameter output  =================================
 
-def write_snp (Smatrix,f, filename):
+def write_snp (Smatrix,f, filename, z0=50):
     # Smatrix input must np.array[s11] or np.array[[s11,s21],[s12,s22]], more ports are also supported
 
     print('Creating  S-parameter file')
@@ -242,7 +242,7 @@ def write_snp (Smatrix,f, filename):
     numfreq = len(f)
 
     snp_file = open(filename, 'w')
-    snp_file.write('#   Hz   S  RI   R   50\n')
+    snp_file.write(f'#   Hz   S  RI   R   {z0:g}\n')
     snp_file.write('!\n')
 
     # address elements as Sij

--- a/workflow/run_dual_dipole.py
+++ b/workflow/run_dual_dipole.py
@@ -142,7 +142,7 @@ if not preview_only:
 
     # write Touchstone S1P file
     s1p_name = os.path.join(sim_path, model_basename + '.s1p')
-    utilities.write_snp (np.array([s11]),f, s1p_name)
+    utilities.write_snp (np.array([s11]),f, s1p_name, z0=simulation_ports.get_reference_impedance())
 
     # plot return loss
     fig, axis = plt.subplots(num="Return Loss", tight_layout=True)

--- a/workflow/run_generic_nport.py
+++ b/workflow/run_generic_nport.py
@@ -155,6 +155,6 @@ for i in range(1, num_ports + 1):
 
 # Write to Touchstone *.snp file
 snp_name = os.path.join(sim_path, model_basename + '.s' + str(num_ports) + 'p')
-utilities.write_snp(s_params, f, snp_name)
+utilities.write_snp(s_params, f, snp_name, z0=simulation_ports.get_reference_impedance())
 
 print('Created S-parameter output file at ', snp_name)

--- a/workflow/run_inductor_2port.py
+++ b/workflow/run_inductor_2port.py
@@ -141,7 +141,7 @@ if preview_only==False:
     s22 = utilities.calculate_Sij (2, 2, f, sim_path, simulation_ports)
 
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     # calculate inductor parameters using Z parameters
     z11 = utilities.calculate_Zij_2port (1, 1, f, sim_path, simulation_ports)

--- a/workflow/run_inductor_diffport.py
+++ b/workflow/run_inductor_diffport.py
@@ -127,12 +127,12 @@ if not preview_only:
   s11 = utilities.calculate_Sij (1, 1, f, sim_path, simulation_ports)
 
   s1p_name = os.path.join(sim_path, model_basename + '.s1p')
-  utilities.write_snp (np.array([s11]),f, s1p_name)
+  Z0 = simulation_ports.get_reference_impedance()
+  utilities.write_snp (np.array([s11]),f, s1p_name, z0=Z0)
 
   # ignore divide by zero warning during inductor calculation at DC
   np.seterr(divide='ignore', invalid='ignore')
 
-  Z0 = simulation_ports.get_port_by_number(1).port_Z0
   zdiff = Z0 * (1+s11)/(1-s11)
   omega = 2*np.pi*f
   Qdiff = zdiff.imag/zdiff.real

--- a/workflow/run_line_GSG_complex.py
+++ b/workflow/run_line_GSG_complex.py
@@ -156,7 +156,9 @@ if not preview_only:
 
     # write Touchstone S2P file
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    # Z0 is the combined GSG/differential reference impedance (see comment above),
+    # not simulation_ports' per-CSX-port port_Z0 (2*Z0) used only for CalcPort()'s wave decomposition
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=Z0)
 
 
     # define dB function for S-parameters

--- a/workflow/run_line_full2port.py
+++ b/workflow/run_line_full2port.py
@@ -148,7 +148,7 @@ if preview_only==False:
 
     # write Touchstone S2P file
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     print('Starting plots')
 

--- a/workflow/run_line_noGDSII.py
+++ b/workflow/run_line_noGDSII.py
@@ -156,7 +156,7 @@ if preview_only==False:
 
     # write Touchstone S2P file
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     fig, axis = plt.subplots(num='Return Loss', tight_layout=True)
     axis.plot(f/1e9, dB(s11), 'k-',  linewidth=2, label='S11 (dB)')

--- a/workflow/run_line_viaport.py
+++ b/workflow/run_line_viaport.py
@@ -150,7 +150,7 @@ if preview_only==False:
 
     # write Touchstone S2P file
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     fig, axis = plt.subplots(num='Return Loss', tight_layout=True)
     axis.plot(f/1e9, dB(s11), 'k-',  linewidth=2, label='S11 (dB)')

--- a/workflow/run_line_viaport_fielddump.py
+++ b/workflow/run_line_viaport_fielddump.py
@@ -165,7 +165,7 @@ if preview_only==False:
 
     # write Touchstone S2P file
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     fig, axis = plt.subplots(num='Return Loss', tight_layout=True)
     axis.plot(f/1e9, dB(s11), 'k-',  linewidth=2, label='S11 (dB)')

--- a/workflow/run_rfcmim_2port_full.py
+++ b/workflow/run_rfcmim_2port_full.py
@@ -143,6 +143,6 @@ if preview_only==False:
     s22 = utilities.calculate_Sij (2, 2, f, sim_path, simulation_ports)
 
     s2p_name = os.path.join(sim_path, model_basename + '.s2p')
-    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name)
+    utilities.write_snp (np.array([[s11, s21],[s12,s22]]),f, s2p_name, z0=simulation_ports.get_reference_impedance())
 
     


### PR DESCRIPTION
## Summary
- `write_snp()` previously hardcoded `R 50` into every `.snp` file's header regardless of the actual simulation port impedance. Added `all_simulation_ports.get_reference_impedance()` and threaded the real reference impedance through to every `write_snp()` call across `workflow/` and `more_examples/` (default stays 50 for backward compatibility with any external caller).
  - `run_line_GSG_complex.py` passes its combined 50 Ohm GSG reference (not the raw 100 Ohm per-CSX-port impedance), matching its existing "50 Ohm GSG port" comment.
- Added `doc/CHANGES.md` (styled after gds2palace_ihp_sg13g2's) and linked it near the top of the README.

## Test plan
- [x] Verified `write_snp()` header renders correctly for an explicit `z0`, the default, and float values (e.g. `100.0` → `R 100`)
- [x] Round-tripped a generated file through `skrf.Network(...)` and confirmed `.z0` matches
- [x] `python -m py_compile` on all 18 touched Python files
- [x] `grep -rn "write_snp"` confirms every in-repo call site now passes `z0=` explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)